### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/RuztyCrabs/Blazelint/security/code-scanning/1](https://github.com/RuztyCrabs/Blazelint/security/code-scanning/1)

To fix the issue, add an explicit `permissions` block to the workflow, setting the minimal required permissions for this job. Since only repository read access is needed (for tasks such as checking out code, caching, and running lint/tests), `contents: read` at the root of the workflow is sufficient. This restricts the `GITHUB_TOKEN` for all jobs unless overridden elsewhere.  
**Edit the `.github/workflows/ci.yml` file:**  
- At the root (after the workflow name and before `on:`), add:
  ```yaml
  permissions:
    contents: read
  ```
No additional methods, imports, or changes to the job steps are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
